### PR TITLE
now outputs all calls to 1 file

### DIFF
--- a/multiStructure.R
+++ b/multiStructure.R
@@ -1,24 +1,16 @@
-##Function to write shell scripts for executing parallel runs of the program STRUCTURE. 
-##File paths can be complete or from the working diretory you intend to use. 
-##structureCommand is the command to run structure - either the path to the 
+##Function to write shell scripts for executing parallel runs of the program STRUCTURE.
+##File paths can be complete or from the working diretory you intend to use.
+##structureCommand is the command to run structure - either the path to the
 #structure.bin file (it's in the .app - right click and go to show contents on a Mac to find it), or just "structure" if you have it in /usr/bin
-##Output will be n shell scripts saved to your working directory, where n is the number of threads.
+##Output will be nruns shell scripts saved to separate lines in file threadme.txt in your working directory.
 ##
-##To run these, just open a separate terminal window for each thread and run one shell script per terminal window. 
-##Note that you'll also need to run <chmod +x shellscript.sh> to make the scripts executable before running them. 
-##This is a pain in the butt, but I don't know a way around it. 
+##To run these shell commands in parallel using the desired number of threads, use threader.py from https://github.com/slager/threader
 
-multiStructure <- function(outfile,structureCommand,mainparams,threads,nruns){ 
+multiStructure <- function(outfile,structureCommand,mainparams,nruns){
   shell <- c()
-  run <- 1
-  for (i in 1:threads) {
-    for (j in 1:(nruns/threads)){
-      command <- paste(structureCommand," -m ",mainparams," -o ",paste(outfile,"_run",run,sep="")," > ",paste(outfile,"_run",run,".log",sep=""),"\n",sep="")
+    for (run in 1:nruns){
+      command <- paste(structureCommand," -m ",mainparams," -o ",paste(outfile,"_run",run,sep="")," > ",paste(outfile,"_run",run,".log",sep=""),sep="")
       shell <- append(shell,command)
-      run <- run+1
     }
-    write(shell,paste("thread_",i,".sh",sep=""))
-    shell <- c()
-  }
+  write(shell,"threadme.txt")
 }
-


### PR DESCRIPTION
The script now outputs all the STRUCTURE calls to a single file, threadme.txt.  Each call is separated by a newline.
One can use threader.py from https://github.com/slager/threader to multi-thread all the STRUCTURE calls in threadme.txt
